### PR TITLE
Allow overriding of root in HashChangeObservable

### DIFF
--- a/can-route-hash-test.js
+++ b/can-route-hash-test.js
@@ -96,3 +96,25 @@ QUnit.test('Can set hash to empty string after it has a value (#3)', function(as
 		teardown();
 	}, assert);
 });
+
+QUnit.test('Can override root on HashChangeObservable', function(assert){
+	var teardown = helpers.setup(function(RouteHash, canReflect, win){
+		win.location.hash = "";
+		var routeHash = new RouteHash();
+		routeHash.root = "#/";
+		var handler = function() {
+			canReflect.offValue(routeHash, handler);
+		};
+		// Set up a binding
+		canReflect.onValue(routeHash, handler);
+
+		win.location.hash = "#/foo";
+		assert.equal(routeHash.value, "foo", "Setting the hash changes the observable");
+
+
+		routeHash.value = "";
+		assert.equal(win.location.hash, "#/", "Updating the observable back to an empty string changes the hash");
+
+		teardown();
+	}, assert);
+});

--- a/can-route-hash.js
+++ b/can-route-hash.js
@@ -11,9 +11,10 @@ var SimpleObservable = require("can-simple-observable");
 
 var domEvents = require("can-dom-events");
 
-function getHash(){
+function getHash(root){
     var loc = LOCATION();
-    return loc.href.split(/#!?/)[1] || "";
+    const re = new RegExp(root +"?");
+    return loc.href.split(re)[1] || "";
 }
 
 function HashchangeObservable() {
@@ -22,7 +23,7 @@ function HashchangeObservable() {
 		this._value = "";
     this.handlers = new KeyTree([Object,Array],{
         onFirst: function(){
-            self._value = getHash();
+            self._value = getHash(self.root);
             domEvents.addEventListener(window, 'hashchange', dispatchHandlers);
         },
         onEmpty: function(){
@@ -41,7 +42,7 @@ canReflect.assign(HashchangeObservable.prototype,{
     root: "#!",
     dispatchHandlers: function() {
         var old = this._value;
-        this._value = getHash();
+        this._value = getHash(this.root);
         if(old !== this._value) {
             queues.enqueueByQueue(this.handlers.getNode([]), this, [this._value, old]
                 //!steal-remove-start
@@ -55,14 +56,14 @@ canReflect.assign(HashchangeObservable.prototype,{
     },
     get: function(){
         ObservationRecorder.add(this);
-        return getHash();
+        return getHash(this.root);
     },
     set: function(path){
         var loc = LOCATION();
         if(!path && !loc.hash) {
 
         } else if(loc.hash !== "#" + path) {
-            loc.hash = "!" + path;
+            loc.hash = this.root.substring(1) + path;
         }
         return path;
     }

--- a/can-route-hash.js
+++ b/can-route-hash.js
@@ -13,8 +13,7 @@ var domEvents = require("can-dom-events");
 
 function getHash(root){
     var loc = LOCATION();
-    const re = new RegExp(root +"?");
-    return loc.href.split(re)[1] || "";
+    return loc.href.split(root)[1] || "";
 }
 
 function HashchangeObservable() {


### PR DESCRIPTION
https://github.com/canjs/can-route/issues/195

Currently can-route-hash is hardcoded to use the ! character and overriding the prototype object doesn't do anything. This makes it so the root is always passed to the lookup functions and we can correctly override the `RouteHash.root`.

### Example:

```javascript
import { route, StacheElement, type, RouteHash } from "can";

RouteHash.prototype.root = '#/'
```

![github](https://user-images.githubusercontent.com/5471079/67351995-6722dd80-f514-11e9-803d-0e620422b94c.gif)
